### PR TITLE
Archivos de prueba de Aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ python3 -m venv venv
 ## Iniciarlizar el entorno virtual para Linux y Mac
 
 ```
-.venv/bin/activate
+source .venv/bin/activate
 ```
 
 ## Instalar las dependecias

--- a/main.py
+++ b/main.py
@@ -8,6 +8,8 @@ import os
 from pytz import timezone
 from bson import ObjectId
 
+# Esta es la versión antes de la prueba de despliegue en Render
+
 load_dotenv('.env')
 app = Flask(__name__)
 app.secret_key = os.getenv('SECRET_KEY', 'default_secret_key')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dotenv
 pymongo
 flask-socketio
 pytz
+boto3

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -12,7 +12,7 @@ body {
 
 .chat-container {
     display: grid;
-    grid-template-columns:48px 400px 1fr;
+    grid-template-columns: 48px 400px 1fr;
     height: 100vh;
     border: 2px solid #333;
     border-radius: 16px;
@@ -34,7 +34,7 @@ body {
 }
 
 .header-icons {
-    display: flex; 
+    display: flex;
     gap: 1.5rem;
 }
 
@@ -151,7 +151,7 @@ body {
 
 .chat-item {
     display: grid;
-    grid-template-areas: 
+    grid-template-areas:
         "avatar name time"
         "avatar info badge";
     grid-template-columns: auto 1fr auto;
@@ -448,6 +448,7 @@ body {
         opacity: 0;
         transform: translateY(10px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);
@@ -497,7 +498,7 @@ body {
 }
 
 .modal-content {
-    background-color: #2a2a2a !important; 
+    background-color: #2a2a2a !important;
     margin: 15% auto;
     padding: 20px;
     border: 1px solid #444;
@@ -507,21 +508,24 @@ body {
     text-align: center;
 }
 
-#contact-username, #group-name  {
+#contact-username,
+#group-name {
     margin-top: 10px;
     color: #056162;
     padding: 5px;
     border-radius: 10px;
 }
 
-#add-contact-submit, #add-group-submit {
+#add-contact-submit,
+#add-group-submit {
     margin: 10px;
     background-color: #056162;
     padding: 5px;
     border-radius: 10px;
 }
 
-#add-contact-submit:hover, #add-group-submit:hover {
+#add-contact-submit:hover,
+#add-group-submit:hover {
     background-color: #0a7373;
     transform: scale(0.95);
     transition: 0.5s;
@@ -579,4 +583,260 @@ body {
 
 .videochat-notification button:hover {
     background-color: #056162;
+}
+
+/* Estilos para los mensajes de archivos */
+.file-message {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: #e0e0e0;
+    text-decoration: none;
+    /*padding: 8px 12px;*/
+    border-radius: 8px;
+    margin: 4px 0;
+    max-width: 100%;
+    word-break: break-word;
+}
+
+.file-message i {
+    font-size: 1.2em;
+    min-width: 20px;
+    text-align: center;
+    flex-shrink: 0;
+}
+
+.file-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: calc(100% - 30px);
+}
+
+.file-message span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.image-message img {
+    max-width: 200px;
+    max-height: 200px;
+    border-radius: 8px;
+    display: block;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+}
+
+.image-message img:hover {
+    transform: scale(1.05);
+}
+
+/* Colores específicos para cada tipo de archivo */
+.message.received .file-message[data-type="document"] {
+    background-color: rgba(25, 118, 210, 0.2);
+}
+
+.message.received .file-message[data-type="code"] {
+    background-color: rgba(76, 175, 80, 0.2);
+}
+
+.message.received .file-message[data-type="archive"] {
+    background-color: rgba(255, 152, 0, 0.2);
+}
+
+.message.received .file-message[data-type="executable"] {
+    background-color: rgba(244, 67, 54, 0.2);
+}
+
+.message.sent .file-message {
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+/* Estilos para el contenedor de carga de archivos */
+#file-upload-container {
+    padding: 10px;
+    background-color: #2a2a2a;
+    border-top: 1px solid #333;
+}
+
+.upload-controls {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+#send-files {
+    background-color: #056162;
+    color: white;
+    border-radius: 5px;
+    padding: 8px 16px;
+}
+
+#cancel-upload {
+    background-color: #444;
+    color: white;
+    padding: 8px 16px;
+    border-radius: 5px;
+}
+
+/* Estilos para FilePond */
+.filepond--panel-root {
+    background-color: #1a1a1a;
+    border: 1px solid #444;
+}
+
+.filepond--drop-label {
+    color: #e0e0e0;
+}
+
+.filepond--label-action {
+    color: #056162;
+}
+
+.filepond--file-action-button {
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+.filepond--file {
+    color: #e0e0e0;
+}
+
+.filepond--file-info {
+    color: #e0e0e0;
+}
+
+.filepond--file-status {
+    color: #8f8f8f;
+}
+
+/* Estilos para archivos que no son imágenes */
+.file-message:not(.image-message) {
+    display: flex;
+    align-items: center;
+    /*gap: 8px;*/
+    color: #e0e0e0;
+    text-decoration: none;
+    /*padding: 8px;*/
+    border-radius: 8px;
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.message.sent .file-message:not(.image-message) {
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+/* Ajustes para mensajes con archivos en móvil */
+@media (max-width: 768px) {
+    .message {
+        max-width: 85% !important;
+        /* Aumentar el ancho máximo en móvil */
+    }
+
+    .message-group {
+        margin-right: 8px;
+        /* Añadir margen para evitar que toque el borde */
+    }
+
+    .file-message {
+        width: 100%;
+        max-width: 100%;
+    }
+
+    .file-name {
+        max-width: calc(100% - 30px);
+    }
+
+    .file-message span {
+        max-width: calc(100% - 30px);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .image-message img {
+        max-width: 100% !important;
+        /* Imágenes responsivas */
+        height: auto;
+        max-height: 300px;
+        /* Altura máxima en móvil */
+        object-fit: contain;
+    }
+
+    /* Ajustes para archivos que no son imágenes */
+    .file-message:not(.image-message) {
+        width: 100%;
+        padding: 8px;
+        word-break: break-all;
+        /* Romper palabras largas */
+    }
+
+    .file-message:not(.image-message) span {
+        max-width: calc(100% - 24px);
+        /* Espacio para el ícono */
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    /* Mejorar la visualización del reproductor de audio */
+    audio {
+        max-width: 100%;
+        margin: 4px 0;
+    }
+
+    /* Ajustar el contenedor de mensajes para mejor espaciado */
+    .messages-container {
+        padding: 0.5rem;
+    }
+
+    /* Mejorar la visualización del nombre del remitente */
+    .message.received strong {
+        display: block;
+        margin-bottom: 4px;
+        font-size: 0.85em;
+    }
+
+    /* Ajustar el tiempo del mensaje */
+    .message-time {
+        font-size: 0.7em;
+        margin-top: 2px;
+    }
+
+    .chat-main {
+        height: 100vh;
+        width: 100%;
+    }
+
+    .message-input-container {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background-color: #1f1f1f;
+        padding: 8px;
+        z-index: 100;
+    }
+
+    .messages-container {
+        margin-bottom: 60px;
+        /* Espacio para el input de mensaje */
+        height: calc(100vh - 120px);
+        /* Ajustar altura considerando header y input */
+    }
+
+    /* Mejorar la visualización del selector de emojis */
+    #emoji-picker-container {
+        position: fixed;
+        bottom: 60px;
+        /* Altura del input de mensaje */
+        left: 0;
+        width: 100%;
+        z-index: 1;
+    }
+
+    .emoji-picker {
+        width: 100% !important;
+        height: 250px !important;
+    }
 }

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -7,8 +7,15 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
   <title>chatpy.io</title>
   <link rel="stylesheet" href="../static/css/styles.css">
+  <link href="https://unpkg.com/filepond/dist/filepond.css" rel="stylesheet">
+  <link href="https://unpkg.com/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css" rel="stylesheet">
   <link rel="icon" type="image/png" sizes="32x32" href="../static/images/favicon.ico" />
   <link rel="icon" type="image/png" sizes="16x16" href="../static/images/favicon.png" />
+  <script src="https://unpkg.com/filepond-plugin-file-encode/dist/filepond-plugin-file-encode.js"></script>
+  <script
+    src="https://unpkg.com/filepond-plugin-file-validate-type/dist/filepond-plugin-file-validate-type.js"></script>
+  <script src="https://unpkg.com/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js"></script>
+  <script src="https://unpkg.com/filepond/dist/filepond.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css">
   <script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1/index.js"></script>
   <script src="https://upload-widget.cloudinary.com/global/all.js" type="text/javascript"></script>
@@ -227,8 +234,17 @@
         <!-- Mensajes se cargarán aquí -->
       </div>
 
+      <div id="file-upload-container"
+        style="display: none; padding: 10px; background-color: #2a2a2a; border-top: 1px solid #333;">
+        <input type="file" class="filepond" name="filepond" multiple>
+        <div class="upload-controls">
+          <button id="cancel-upload" class="action-button">Cancelar</button>
+          <button id="send-files" class="action-button">Enviar</button>
+        </div>
+      </div>
+
       <div class="message-input-container">
-        <button class="action-button">
+        <button class="action-button" id="file-button">
           <i class="fas fa-paperclip"></i>
         </button>
         <button class="action-button" id="emoji-button">
@@ -486,34 +502,42 @@
 
     // Manejo de nuevos mensajes: se muestran si corresponden al chat activo, y si no, se actualiza el badge
     socket.on('new_message', (data) => {
-      const { sender, receiver, message, type, audio_url, _id, sender_avatar } = data;
+      const { sender, sender_id, receiver, message, type, audio_url, file_url, file_type, _id, sender_avatar } = data;
+
+      // Determinar si el mensaje es enviado o recibido
+      const isSentByMe = sender_id === sessionUserId;
+      const msgType = isSentByMe ? 'sent' : 'received';
 
       // Determinar si debemos reproducir el sonido (solo si el mensaje no es del usuario actual)
-      const shouldPlaySound = sender !== sessionUserId;
+      const shouldPlaySound = !isSentByMe;
 
       if (type === 'group') {
         if (currentChatType === 'group' && receiver === currentChatUserId) {
           if (audio_url) {
-            addAudioMessageToChat(sender, audio_url, sender === sessionUserId ? 'sent' : 'received', null, sender_avatar, _id);
-          } else {
-            addMessageToChat(sender, message, sender === sessionUserId ? 'sent' : 'received', null, sender_avatar, _id);
+            addAudioMessageToChat(sender, audio_url, msgType, null, sender_avatar, _id);
+          } else if (file_url && file_type) {
+            addFileMessageToChat(sender, file_url, file_type, msgType, null, sender_avatar, _id);
+          } else if (message) {
+            addMessageToChat(sender, message, msgType, null, sender_avatar, _id);
           }
         } else {
           updateUnreadBadge(receiver);
-          if (shouldPlaySound) playNotificationSound(); // Reproducir sonido solo si no es un mensaje propio
+          if (shouldPlaySound) playNotificationSound();
         }
       } else {
         // Mensaje privado
-        if (currentChatType === 'private' && (sender === currentChatUserId || receiver === currentChatUserId)) {
+        if (currentChatType === 'private' && (sender_id === currentChatUserId || receiver === currentChatUserId)) {
           if (audio_url) {
-            addAudioMessageToChat(sender, audio_url, sender === sessionUserId ? 'sent' : 'received', null, sender_avatar, _id);
-          } else {
-            addMessageToChat(sender, message, sender === sessionUserId ? 'sent' : 'received', null, sender_avatar, _id);
+            addAudioMessageToChat(sender, audio_url, msgType, null, sender_avatar, _id);
+          } else if (file_url && file_type) {
+            addFileMessageToChat(sender, file_url, file_type, msgType, null, sender_avatar, _id);
+          } else if (message) {
+            addMessageToChat(sender, message, msgType, null, sender_avatar, _id);
           }
         } else {
-          const chatId = (sender === sessionUserId) ? receiver : sender;
+          const chatId = isSentByMe ? receiver : sender_id;
           updateUnreadBadge(chatId);
-          if (shouldPlaySound) playNotificationSound(); // Reproducir sonido solo si no es un mensaje propio
+          if (shouldPlaySound) playNotificationSound();
         }
       }
     });
@@ -611,12 +635,19 @@
             messagesContainer.innerHTML = '';
             data.messages.forEach(message => {
               const msgType = message.sender_id === sessionUserId ? 'sent' : 'received';
+
+              // Manejar diferentes tipos de mensajes
               if (message.audio_url) {
                 addAudioMessageToChat(message.sender, message.audio_url, msgType, message.sent_at, message.sender_avatar);
-              } else {
+              } else if (message.file_url && message.file_type) {
+                // Renderizar mensajes de archivo
+                addFileMessageToChat(message.sender, message.file_url, message.file_type, msgType, message.sent_at, message.sender_avatar);
+              } else if (message.message) {
+                // Mensajes de texto normales
                 addMessageToChat(message.sender, message.message, msgType, message.sent_at, message.sender_avatar);
               }
             });
+
             // Actualizar el avatar y el título del chat
             const contact = data.contact;
             document.getElementById('chat-avatar').src = contact.profile_pic;
@@ -638,12 +669,19 @@
             messagesContainer.innerHTML = '';
             data.messages.forEach(message => {
               const msgType = message.sender_id === sessionUserId ? 'sent' : 'received';
+
+              // Manejar diferentes tipos de mensajes
               if (message.audio_url) {
                 addAudioMessageToChat(message.sender, message.audio_url, msgType, message.sent_at, message.sender_avatar);
-              } else {
+              } else if (message.file_url && message.file_type) {
+                // Renderizar mensajes de archivo
+                addFileMessageToChat(message.sender, message.file_url, message.file_type, msgType, message.sent_at, message.sender_avatar);
+              } else if (message.message) {
+                // Mensajes de texto normales
                 addMessageToChat(message.sender, message.message, msgType, message.sent_at, message.sender_avatar);
               }
             });
+
             // Actualizar el avatar y el título del grupo
             const group = data.group;
             document.getElementById('chat-avatar').src = group.profile_pic || 'https://via.placeholder.com/150?text=Grupo';
@@ -693,6 +731,49 @@
     }
 
     document.addEventListener('DOMContentLoaded', function () {
+      const fileButton = document.getElementById('file-button');
+      const fileUploadContainer = document.getElementById('file-upload-container');
+      const cancelUploadButton = document.getElementById('cancel-upload');
+      const sendFilesButton = document.getElementById('send-files');
+      let pond;
+
+      // Inicializar FilePond
+      pond = initializeFilePond();
+      // Mostrar/ocultar el contenedor de carga de archivos
+      fileButton.addEventListener('click', function () {
+        fileUploadContainer.style.display = fileUploadContainer.style.display === 'none' ? 'block' : 'none';
+      });
+
+      // Cancelar la carga de archivos
+      cancelUploadButton.addEventListener('click', function () {
+        pond.removeFiles();
+        fileUploadContainer.style.display = 'none';
+      });
+
+      // Enviar archivos
+      sendFilesButton.addEventListener('click', async function () {
+        const files = pond.getFiles();
+        if (files.length === 0) return;
+
+        // Mostrar indicador de carga
+        sendFilesButton.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Enviando...';
+        sendFilesButton.disabled = true;
+
+        // Subir archivos a S3
+        const fileUrls = await uploadFilesToS3(files);
+
+        // Enviar archivos en el chat
+        await sendFiles(fileUrls);
+
+        // Limpiar y ocultar el contenedor de carga
+        pond.removeFiles();
+        fileUploadContainer.style.display = 'none';
+
+        // Restaurar el botón
+        sendFilesButton.innerHTML = 'Enviar';
+        sendFilesButton.disabled = false;
+      });
+
       // Cargar la preferencia de notificaciones guardada
       const savedNotificationPreference = localStorage.getItem('notificationsEnabled');
       if (savedNotificationPreference !== null) {
@@ -1064,12 +1145,12 @@
                 type: currentChatType,
                 audio_url: audioUrl
               };
-              
+
               // Enviar el mensaje a través de Socket.IO
               socket.emit('send_message', data);
-              
+
               // NO agregar el mensaje manualmente aquí, ya que llegará a través de Socket.IO
-              
+
               // Detener todas las pistas del stream para liberar el micrófono
               stream.getTracks().forEach(track => track.stop());
             }
@@ -1172,6 +1253,279 @@
         })
         .catch(error => console.error('Error:', error));
     }
+
+    // Función para inicializar FilePond
+    // Función para inicializar FilePond con más tipos de archivos permitidos
+    function initializeFilePond() {
+      // Registrar plugins de FilePond
+      FilePond.registerPlugin(
+        FilePondPluginFileEncode,
+        FilePondPluginFileValidateType,
+        FilePondPluginImagePreview
+      );
+
+      // Crear instancia de FilePond
+      const pond = FilePond.create(document.querySelector('.filepond'), {
+        allowMultiple: true,
+        maxFiles: 5,
+        // Ampliar los tipos de archivos aceptados
+        acceptedFileTypes: [
+          'image/*',                                                  // Imágenes
+          'application/pdf',                                          // PDF
+          'application/msword',                                       // DOC
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // DOCX
+          'application/vnd.ms-powerpoint',                            // PPT
+          'application/vnd.openxmlformats-officedocument.presentationml.presentation', // PPTX
+          'application/vnd.ms-excel',                                 // XLS
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // XLSX
+          'text/plain',                                               // TXT
+          'text/html',                                                // HTML
+          'text/css',                                                 // CSS
+          'text/javascript',                                          // JS
+          'application/json',                                         // JSON
+          'application/xml',                                          // XML
+          'application/zip',                                          // ZIP
+          'application/x-rar-compressed',                             // RAR
+          'application/x-7z-compressed',                              // 7Z
+          'application/x-msdownload',                                 // EXE
+          'application/x-sh',                                         // SH
+          'application/x-python',                                     // Python
+          'application/java-archive',                                 // JAR
+          'application/octet-stream'                                  // Binarios genéricos
+        ],
+        labelIdle: 'Arrastra y suelta archivos o <span class="filepond--label-action">Examinar</span>',
+        labelFileTypeNotAllowed: 'Tipo de archivo no válido',
+        fileValidateTypeLabelExpectedTypes: 'Se esperan archivos de tipo {allTypes}',
+        labelMaxFileSizeExceeded: 'El archivo es demasiado grande',
+        labelMaxFileSize: 'El tamaño máximo de archivo es {filesize}',
+        maxFileSize: '20MB' // Aumentar el tamaño máximo para archivos más grandes
+      });
+
+      return pond;
+    }
+
+    // Función para subir un archivo a AWS S3
+    async function uploadFileToS3(file) {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      try {
+        const response = await fetch('/upload_file', {
+          method: 'POST',
+          body: formData
+        });
+
+        const data = await response.json();
+        if (data.status === 'success') {
+          return data.file_url;
+        } else {
+          console.error('Error al subir archivo:', data.message);
+          return null;
+        }
+      } catch (error) {
+        console.error('Error al subir archivo:', error);
+        return null;
+      }
+    }
+
+    // Función para subir múltiples archivos a S3
+    async function uploadFilesToS3(files) {
+      const uploadPromises = files.map(file => {
+        return uploadFileToS3(file.file);
+      });
+
+      try {
+        const fileUrls = await Promise.all(uploadPromises);
+        return fileUrls.filter(url => url !== null);
+      } catch (error) {
+        console.error('Error al subir archivos:', error);
+        return [];
+      }
+    }
+
+    // Función para enviar archivos en el chat
+    async function sendFiles(fileUrls) {
+      if (fileUrls.length === 0 || !currentChatUserId) return;
+
+      for (const fileUrl of fileUrls) {
+        const fileType = getFileTypeFromUrl(fileUrl);
+        const data = {
+          sender: sessionUserId,
+          sender_id: sessionUserId,
+          receiver: currentChatUserId,
+          type: currentChatType,
+          file_url: fileUrl,
+          file_type: fileType
+        };
+
+        // Enviar el mensaje a través de Socket.IO
+        socket.emit('send_message', data);
+      }
+    }
+
+    // Función mejorada para determinar el tipo de archivo basado en la URL
+    function getFileTypeFromUrl(url) {
+      const extension = url.split('.').pop().toLowerCase().split('?')[0];
+
+      const imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg', 'ico'];
+      const documentExtensions = [
+        'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'txt', 'rtf', 'odt', 'ods', 'odp'
+      ];
+      const codeExtensions = [
+        'html', 'css', 'js', 'ts', 'jsx', 'tsx', 'json', 'xml', 'yaml', 'yml',
+        'py', 'java', 'c', 'cpp', 'cs', 'php', 'rb', 'go', 'swift', 'kt', 'rs'
+      ];
+      const archiveExtensions = ['zip', 'rar', '7z', 'tar', 'gz', 'bz2', 'xz'];
+      const executableExtensions = ['exe', 'msi', 'bin', 'sh', 'bat', 'cmd', 'app', 'jar', 'apk'];
+
+      if (imageExtensions.includes(extension)) return 'image';
+      if (documentExtensions.includes(extension)) return 'document';
+      if (codeExtensions.includes(extension)) return 'code';
+      if (archiveExtensions.includes(extension)) return 'archive';
+      if (executableExtensions.includes(extension)) return 'executable';
+
+      return 'other';
+    }
+
+    function addFileMessageToChat(sender, fileUrl, fileType, tipo = 'received', timestamp = null, avatar = '', messageId = null) {
+      // Verificar si el mensaje ya ha sido procesado
+      if (messageId && processedMessageIds.has(messageId)) {
+        return;
+      }
+
+      const templateId = tipo === 'sent' ? 'message-template-sent' : 'message-template-received';
+      const template = document.getElementById(templateId).content.cloneNode(true);
+
+      if (tipo === 'received') {
+        template.querySelector('strong').textContent = sender;
+        template.querySelector('.avatar img').src = avatar || '/placeholder.svg';
+      }
+
+      const timeString = timestamp
+        ? new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+        : new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+      // Crear el elemento según el tipo de archivo
+      let fileElement;
+
+      if (fileType === 'image') {
+        fileElement = document.createElement('a');
+        fileElement.href = fileUrl;
+        fileElement.setAttribute('data-fancybox', 'gallery');
+        fileElement.className = 'file-message image-message';
+
+        const img = document.createElement('img');
+        img.src = fileUrl;
+        img.alt = 'Imagen compartida';
+        img.style.maxWidth = '200px';
+        img.style.maxHeight = '200px';
+        img.style.borderRadius = '8px';
+
+        fileElement.appendChild(img);
+      } else {
+        fileElement = document.createElement('a');
+        fileElement.href = fileUrl;
+        fileElement.target = '_blank';
+        fileElement.className = 'file-message';
+        fileElement.setAttribute('data-type', fileType); // Para aplicar estilos específicos
+
+        const icon = document.createElement('i');
+
+        // Asignar el icono correcto según el tipo de archivo
+        switch (fileType) {
+          case 'document':
+            icon.className = 'fas fa-file-alt';
+            break;
+          case 'code':
+            icon.className = 'fas fa-file-code';
+            break;
+          case 'archive':
+            icon.className = 'fas fa-file-archive';
+            break;
+          case 'executable':
+            icon.className = 'fas fa-file-code';
+            break;
+          default:
+            icon.className = 'fas fa-file';
+        }
+
+        // Extraer solo el nombre real del archivo sin el ID
+        const fullPath = decodeURIComponent(fileUrl.split('/').pop().split('?')[0]);
+
+        // Intentar extraer solo el nombre del archivo sin el ID
+        let fileName;
+
+        // Buscar patrones comunes como "ID_nombrearchivo.ext"
+        const fileNameMatch = fullPath.match(/[a-f0-9]+_(.+)$/);
+        if (fileNameMatch && fileNameMatch[1]) {
+          fileName = fileNameMatch[1]; // Usar solo la parte después del ID y guion bajo
+        } else {
+          // Si no se encuentra el patrón, usar el nombre completo
+          fileName = fullPath;
+        }
+
+        const fileNameElement = document.createElement('span');
+        fileNameElement.className = 'file-name';
+
+        // Truncar nombres largos (más de 20 caracteres)
+        if (fileName.length > 20) {
+          const extension = fileName.lastIndexOf('.') > -1 ? fileName.substring(fileName.lastIndexOf('.')) : '';
+          const baseName = fileName.substring(0, fileName.lastIndexOf('.') > -1 ? fileName.lastIndexOf('.') : fileName.length);
+
+          if (baseName.length > 16) {
+            // Truncar el nombre base y mantener la extensión
+            fileNameElement.textContent = baseName.substring(0, 16) + '...' + extension;
+            // Agregar el nombre completo como tooltip
+            fileNameElement.title = fileName;
+          } else {
+            fileNameElement.textContent = fileName;
+          }
+        } else {
+          fileNameElement.textContent = fileName;
+        }
+
+        fileElement.appendChild(icon);
+        fileElement.appendChild(document.createTextNode(' '));
+        fileElement.appendChild(fileNameElement);
+
+        // Aplicar estilos según el tipo de mensaje
+        fileElement.style.display = 'flex';
+        fileElement.style.alignItems = 'center';
+        fileElement.style.gap = '8px';
+        fileElement.style.color = '#e0e0e0';
+        fileElement.style.textDecoration = 'none';
+        fileElement.style.padding = '8px';
+        fileElement.style.backgroundColor = tipo === 'sent' ? '#056162' : '#2a2a2a';
+        fileElement.style.borderRadius = '8px';
+        fileElement.style.maxWidth = '100%';
+
+        // Estilos para el nombre del archivo
+        fileNameElement.style.overflow = 'hidden';
+        fileNameElement.style.textOverflow = 'ellipsis';
+        fileNameElement.style.whiteSpace = 'nowrap';
+        fileNameElement.style.maxWidth = 'calc(100% - 30px)';
+      }
+
+      template.querySelector('p').replaceWith(fileElement);
+      template.querySelector('.message-time').textContent = timeString;
+
+      const messagesContainer = document.querySelector('.messages-container');
+      messagesContainer.appendChild(template);
+      scrollToBottom(messagesContainer);
+
+      // Inicializar Fancybox para las imágenes
+      if (fileType === 'image') {
+        $('[data-fancybox="gallery"]').fancybox({
+          buttons: ['zoom', 'download', 'close']
+        });
+      }
+
+      // Agregar el ID del mensaje a la lista de procesados
+      if (messageId) {
+        processedMessageIds.add(messageId);
+      }
+    }
+
   </script>
   <audio id="notification-sound" preload="auto">
     <source src="../static/notifications/notification.mp3" type="audio/mpeg">

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -12,6 +12,21 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css">
   <script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1/index.js"></script>
   <script src="https://upload-widget.cloudinary.com/global/all.js" type="text/javascript"></script>
+  <script src="https://sdk.amazonaws.com/js/aws-sdk-2.1259.0.min.js"></script>
+  <!-- CSS de Fancybox -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.css">
+
+  <!-- jQuery -->
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+
+  <!-- JS de Fancybox -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js"></script>
+
+  <!-- CSS de Plyr -->
+  <link rel="stylesheet" href="https://cdn.plyr.io/3.7.8/plyr.css" />
+
+  <!-- JS de Plyr -->
+  <script src="https://cdn.plyr.io/3.7.8/plyr.polyfilled.js"></script>
   <style>
     /* Estilos para dispositivos móviles */
     @media (max-width: 768px) {
@@ -225,7 +240,7 @@
         <button class="action-button" id="send-button">
           <i class="fas fa-paper-plane"></i>
         </button>
-        <button class="action-button" id="mic-button">
+        <button id="grabar-audio" class="action-button">
           <i class="fas fa-microphone"></i>
         </button>
       </div>
@@ -313,6 +328,8 @@
     const socket = io();
     let currentRoomId = null;
     let notificationsEnabled = true;
+    let s3; // Definir la variable s3
+    let S3_BUCKET_NAME; // Definir la variable S3_BUCKET_NAME
 
     function playNotificationSound() {
       if (!notificationsEnabled) return; // No reproducir si las notificaciones están desactivadas
@@ -464,16 +481,23 @@
       }
     });
 
+    // Lista para almacenar los IDs de los mensajes ya procesados
+    const processedMessageIds = new Set();
+
     // Manejo de nuevos mensajes: se muestran si corresponden al chat activo, y si no, se actualiza el badge
     socket.on('new_message', (data) => {
-      const { sender, receiver, message, type } = data;
+      const { sender, receiver, message, type, audio_url, _id, sender_avatar } = data;
 
       // Determinar si debemos reproducir el sonido (solo si el mensaje no es del usuario actual)
       const shouldPlaySound = sender !== sessionUserId;
 
       if (type === 'group') {
         if (currentChatType === 'group' && receiver === currentChatUserId) {
-          addMessageToChat(sender, message, sender === sessionUserId ? 'sent' : 'received');
+          if (audio_url) {
+            addAudioMessageToChat(sender, audio_url, sender === sessionUserId ? 'sent' : 'received', null, sender_avatar, _id);
+          } else {
+            addMessageToChat(sender, message, sender === sessionUserId ? 'sent' : 'received', null, sender_avatar, _id);
+          }
         } else {
           updateUnreadBadge(receiver);
           if (shouldPlaySound) playNotificationSound(); // Reproducir sonido solo si no es un mensaje propio
@@ -481,7 +505,11 @@
       } else {
         // Mensaje privado
         if (currentChatType === 'private' && (sender === currentChatUserId || receiver === currentChatUserId)) {
-          addMessageToChat(sender, message, sender === sessionUserId ? 'sent' : 'received');
+          if (audio_url) {
+            addAudioMessageToChat(sender, audio_url, sender === sessionUserId ? 'sent' : 'received', null, sender_avatar, _id);
+          } else {
+            addMessageToChat(sender, message, sender === sessionUserId ? 'sent' : 'received', null, sender_avatar, _id);
+          }
         } else {
           const chatId = (sender === sessionUserId) ? receiver : sender;
           updateUnreadBadge(chatId);
@@ -545,6 +573,35 @@
       scrollToBottom(messagesContainer);
     }
 
+    function addAudioMessageToChat(nombre, audioUrl, tipo = 'received', timestamp = null, avatar = '', messageId = null) {
+      // Verificar si el mensaje ya ha sido procesado
+      if (messageId && processedMessageIds.has(messageId)) {
+        return;
+      }
+
+      const templateId = tipo === 'sent' ? 'message-template-sent' : 'message-template-received';
+      const template = document.getElementById(templateId).content.cloneNode(true);
+      if (tipo === 'received') {
+        template.querySelector('strong').textContent = nombre;
+        template.querySelector('.avatar img').src = avatar;
+      }
+      const timeString = timestamp ? new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+        : new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      const audioElement = document.createElement('audio');
+      audioElement.src = audioUrl;
+      audioElement.controls = true;
+      template.querySelector('p').replaceWith(audioElement);
+      template.querySelector('.message-time').textContent = timeString;
+      const messagesContainer = document.querySelector('.messages-container');
+      messagesContainer.appendChild(template);
+      scrollToBottom(messagesContainer);
+
+      // Agregar el ID del mensaje a la lista de procesados
+      if (messageId) {
+        processedMessageIds.add(messageId);
+      }
+    }
+
     function loadMessagesWith(contactId) {
       fetch(`/get_messages_with/${contactId}`)
         .then(response => response.json())
@@ -554,7 +611,11 @@
             messagesContainer.innerHTML = '';
             data.messages.forEach(message => {
               const msgType = message.sender_id === sessionUserId ? 'sent' : 'received';
-              addMessageToChat(message.sender, message.message, msgType, message.sent_at, message.sender_avatar);
+              if (message.audio_url) {
+                addAudioMessageToChat(message.sender, message.audio_url, msgType, message.sent_at, message.sender_avatar);
+              } else {
+                addMessageToChat(message.sender, message.message, msgType, message.sent_at, message.sender_avatar);
+              }
             });
             // Actualizar el avatar y el título del chat
             const contact = data.contact;
@@ -577,7 +638,11 @@
             messagesContainer.innerHTML = '';
             data.messages.forEach(message => {
               const msgType = message.sender_id === sessionUserId ? 'sent' : 'received';
-              addMessageToChat(message.sender, message.message, msgType, message.sent_at, message.sender_avatar);
+              if (message.audio_url) {
+                addAudioMessageToChat(message.sender, message.audio_url, msgType, message.sent_at, message.sender_avatar);
+              } else {
+                addMessageToChat(message.sender, message.message, msgType, message.sent_at, message.sender_avatar);
+              }
             });
             // Actualizar el avatar y el título del grupo
             const group = data.group;
@@ -651,6 +716,7 @@
 
       loadContacts();
       loadGroups();
+      getAWSCredentials();
     });
 
     // Agregar item de contacto a la lista de chats (se asigna data-id)
@@ -894,6 +960,11 @@
     const CLOUDINARY_CLOUD_NAME = 'dmyejrbs7';
     const CLOUDINARY_UPLOAD_PRESET = 'apuntes';
 
+    let mediaRecorder;
+    let audioChunks = [];
+    let audioUrl = null;
+    let audioBlob = null;
+
     function openCloudinaryUploader() {
       cloudinary.openUploadWidget({
         cloudName: CLOUDINARY_CLOUD_NAME,
@@ -935,6 +1006,71 @@
             .catch(error => console.error('Error:', error));
         }
       });
+    }
+
+    document.getElementById('grabar-audio').addEventListener('click', grabarAudio);
+
+    async function subirAudio(blob) {
+      const params = {
+        Bucket: S3_BUCKET_NAME,
+        Key: 'audios/' + Date.now() + '.webm',
+        Body: blob,
+        ContentType: 'audio/webm'
+      };
+
+      try {
+        const data = await s3.upload(params).promise();
+        console.log('Audio subido con éxito:', data.Location);
+        return data.Location;
+      } catch (error) {
+        console.error('Error al subir el audio:', error);
+        alert('Error al subir el audio. Por favor, revisa la consola para más detalles.');
+        return null;
+      }
+    }
+
+    function grabarAudio() {
+      const button = document.getElementById('grabar-audio');
+
+      if (mediaRecorder && mediaRecorder.state === "recording") {
+        mediaRecorder.stop();
+        button.innerHTML = '<i class="fas fa-microphone"></i>'; // Restaurar el ícono original
+        return;
+      }
+
+      navigator.mediaDevices.getUserMedia({ audio: true })
+        .then(stream => {
+          mediaRecorder = new MediaRecorder(stream);
+          mediaRecorder.start();
+          button.innerHTML = '<i class="fas fa-stop"></i>'; // Cambiar a ícono de detener
+
+          audioChunks = [];
+          mediaRecorder.addEventListener("dataavailable", event => {
+            audioChunks.push(event.data);
+          });
+
+          mediaRecorder.addEventListener("stop", async () => {
+            const blob = new Blob(audioChunks, { type: 'audio/webm' });
+            const audioUrl = await subirAudio(blob);
+            if (audioUrl) {
+              const data = {
+                sender: sessionUserId,
+                receiver: currentChatUserId,
+                type: currentChatType,
+                audio_url: audioUrl
+              };
+              
+              // Enviar el mensaje a través de Socket.IO
+              socket.emit('send_message', data);
+              
+              // NO agregar el mensaje manualmente aquí, ya que llegará a través de Socket.IO
+              
+              // Detener todas las pistas del stream para liberar el micrófono
+              stream.getTracks().forEach(track => track.stop());
+            }
+          });
+        })
+        .catch(error => console.error('Error al grabar audio:', error));
     }
 
     // Asignar el evento al botón de la barra lateral
@@ -1009,6 +1145,27 @@
             .catch(error => console.error('Error:', error));
         }
       });
+    }
+
+    // Función para obtener las credenciales de AWS
+    function getAWSCredentials() {
+      fetch('/get_aws_credentials')
+        .then(response => response.json())
+        .then(data => {
+          if (data.status === 'success') {
+            AWS.config.update({
+              accessKeyId: data.access_key,
+              secretAccessKey: data.secret_key,
+              region: 'us-east-2' // Ejemplo: 'us-east-1'
+            });
+            S3_BUCKET_NAME = data.s3_bucket;
+            s3 = new AWS.S3(); // Inicializar la variable s3
+            console.log('Credenciales de AWS obtenidas con éxito');
+          } else {
+            console.error('Error al obtener credenciales de AWS:', data.message);
+          }
+        })
+        .catch(error => console.error('Error:', error));
     }
   </script>
   <audio id="notification-sound" preload="auto">

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1032,6 +1032,11 @@
     function grabarAudio() {
       const button = document.getElementById('grabar-audio');
 
+      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        alert('Tu navegador no soporta la grabación de audio. Por favor, usa un navegador compatible como Chrome o Firefox.');
+        return;
+      }
+
       if (mediaRecorder && mediaRecorder.state === "recording") {
         mediaRecorder.stop();
         button.innerHTML = '<i class="fas fa-microphone"></i>'; // Restaurar el ícono original


### PR DESCRIPTION
This pull request introduces file upload and sharing functionality to the chat application, including backend support for storing files in AWS S3, new API endpoints for AWS credentials and file uploads, and frontend styles for displaying file messages. It also improves message handling to support audio and file attachments, and includes various UX and code quality enhancements.

**Backend: File Uploads & AWS Integration**
- Added new Flask routes for retrieving AWS credentials (`/get_api_key_aws`, `/get_aws_credentials`) and uploading files to S3 (`/upload_file`). The upload endpoint handles file type detection, generates unique filenames, and returns a public URL for the uploaded file.
- Integrated `boto3` for AWS S3 interactions and added `secure_filename` import for safe file handling.

**Message Model & Handling Enhancements**
- Extended message creation (in both REST and WebSocket handlers) to support and store `audio_url`, `file_url`, and `file_type` fields, enabling audio and file sharing in messages. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L31-R50) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L394-R551)
- Updated message retrieval endpoints to ensure `file_url` and `file_type` are always present in message objects, preventing frontend errors. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R146-R151) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R172-R181)

**Frontend: File Message Styles**
- Added comprehensive CSS for displaying file messages, including color coding by file type, responsive design for mobile, and specific styles for image and non-image files. Also included styles for the file upload UI and FilePond integration.
- Improved CSS selector formatting and hover effects for contact and group buttons.

**Documentation**
- Corrected the command for activating the Python virtual environment in the `README.md` for Linux/Mac users.